### PR TITLE
Add GitHub Skills activity to course catalog

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity that was announced by the principal during the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities database
- Set max capacity to 25 students
- Scheduled for Wednesdays, 3:30 PM - 5:00 PM
- Includes description highlighting the GitHub Certifications program and college application benefits

## Context
Students have been trying to sign up for this activity after the principal's announcement about a new partnership with GitHub. The activity teaches practical coding and collaboration skills and is part of the GitHub Certifications program.

This is time-sensitive as registrations close by the end of this week.

Fixes #6